### PR TITLE
Add suppress warnings key

### DIFF
--- a/src/main/java/org/checkerframework/checker/templatefora/TemplateforaChecker.java
+++ b/src/main/java/org/checkerframework/checker/templatefora/TemplateforaChecker.java
@@ -1,6 +1,7 @@
 package org.checkerframework.checker.templatefora;
 
 import org.checkerframework.common.basetype.BaseTypeChecker;
+import org.checkerframework.framework.source.SuppressWarningsKeys;
 
 /**
  * Empty Checker is the entry point for pluggable type-checking.
@@ -8,4 +9,5 @@ import org.checkerframework.common.basetype.BaseTypeChecker;
  * <p>This one does nothing. The Checker Framework manual tells you how to make it do something:
  * https://checkerframework.org/manual/#creating-a-checker
  */
+@SuppressWarningsKeys({"templatefora"})
 public class TemplateforaChecker extends BaseTypeChecker {}


### PR DESCRIPTION
All checkers should define one or more suppress warnings keys, so that users can easily suppress warnings from them. The template should model this behavior by defining a key for itself, too.

The instructions don't need to change, since they already tell the user to find and replace each instance of "templatefora" with their own checker's name, which is a reasonable default suppress warnings key.