### PR TITLE
Add tests build folder to cleaning logic

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,3 +44,7 @@ publishing {
         }
     }
 }
+
+clean.doFirst {
+    delete "${rootDir}/tests/build/"
+}


### PR DESCRIPTION
The `./gradlew clean` target, by default, does not delete the class files in the `tests/build/testclasses` folder, where the class files generated from test data are stored. This PR adds build logic so that that directory is also removed when the `clean` target is run.