### PR TITLE
Add errorProne Javac so that tests can run correctly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: java
+install: true
+
+jdk:
+  - openjdk8
+
+script:
+  - ./gradlew build --stacktrace

--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,16 @@ repositories {
     jcenter()
 }
 
+configurations {
+    // for putting Error Prone javac in bootclasspath for running tests
+    errorproneJavac
+}
+
+ext.versions = [
+        checkerFramework: "2.11.0",
+]
+
+
 sourceCompatibility = 1.8
 def checkerframework_local = false  // Set this variable to [true] while using local version of checker framework.
 
@@ -20,12 +30,14 @@ dependencies {
         implementation files('${CHECKERFRAMEWORK}/checker/dist/jdk8.jar')
     }
     else {
-        implementation 'org.checkerframework:checker:2.11.0'
+        implementation "org.checkerframework:checker:${versions.checkerFramework}"
     }
 
     // Testing
     testImplementation 'junit:junit:4.12'
-    testCompile 'org.checkerframework:testlib:2.5.4'
+    testCompile "org.checkerframework:framework-test:${versions.checkerFramework}"
+
+    errorproneJavac "com.google.errorprone:javac:9+181-r4173-1"
 }
 
 tasks.withType(JavaCompile).all {
@@ -47,6 +59,9 @@ publishing {
 
 test {
     inputs.files("tests/templatefora")
+    if (!JavaVersion.current().java9Compatible) {
+        jvmArgs "-Xbootclasspath/p:${configurations.errorproneJavac.asPath}"
+    }
 }
 
 clean.doFirst {


### PR DESCRIPTION
This PR also enables Travis by adding a `.travis.yml` file, so that this repo has CI.

Fixes #14.