### PR TITLE
Fix annotationProcessor's name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ repositories {
     mavenCentral()
 }
 dependencies {
-    annotationProcessor 'org.checkerframework.checker.templatefora:0.1-SNAPSHOT'
+    annotationProcessor 'org.checkerframework:templatefora-checker:0.1-SNAPSHOT'
 }
 ```
 


### PR DESCRIPTION
According to [build.gradle](https://github.com/typetools/templatefora-checker/blob/master/build.gradle#L52) and the naming rule `groupId:artifactId:version`.