### PR TITLE
Add printClasspath target

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ clean.doFirst {
 }
 
 task printClasspath {
-    description: 'Prints the runtime classpath of the checker. When using the checker to typecheck' +
+    description 'Prints the runtime classpath of the checker. When using the checker to typecheck' +
             'another project, you should put the result of running this task on either the processor' +
             'path or the classpath of the target project.'
     doLast {

--- a/build.gradle
+++ b/build.gradle
@@ -69,3 +69,12 @@ test {
 clean.doFirst {
     delete "${rootDir}/tests/build/"
 }
+
+// This task prints the classpath for this checker and its dependencies. When using this checker
+// to typecheck another project, you should put the result of running this task on either the
+// processor path or the classpath of the target project.
+task printClasspath {
+    doLast {
+        println sourceSets.main.runtimeClasspath.asPath
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -70,10 +70,10 @@ clean.doFirst {
     delete "${rootDir}/tests/build/"
 }
 
-// This task prints the classpath for this checker and its dependencies. When using this checker
-// to typecheck another project, you should put the result of running this task on either the
-// processor path or the classpath of the target project.
 task printClasspath {
+    description: 'Prints the runtime classpath of the checker. When using the checker to typecheck' +
+            'another project, you should put the result of running this task on either the processor' +
+            'path or the classpath of the target project.'
     doLast {
         println sourceSets.main.runtimeClasspath.asPath
     }


### PR DESCRIPTION
The checker's classpath is necessary when running a custom checker. 

I copied the definition of the task from the Object Construction Checker: https://github.com/kelloggm/object-construction-checker/blob/master/object-construction-checker/build.gradle#L94