### PR TITLE
Use Checker Framework version 3.10.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ configurations {
 }
 
 ext.versions = [
-        checkerFramework: "3.9.1",
+    checkerFramework: "3.10.0",
 ]
 
 
@@ -30,6 +30,7 @@ dependencies {
     }
     else {
         implementation "org.checkerframework:checker:${versions.checkerFramework}"
+        implementation "org.checkerframework:checker-qual:${versions.checkerFramework}"
     }
 
     compileOnly "com.google.errorprone:javac:9+181-r4173-1"

--- a/templatefora-checker-qual/build.gradle
+++ b/templatefora-checker-qual/build.gradle
@@ -7,8 +7,8 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.checkerframework:checker:3.10.0'
-    implementation 'org.checkerframework:checker-qual:3.10.0'
+    implementation "org.checkerframework:checker:${versions.checkerFramework}"
+    implementation "org.checkerframework:checker-qual:${versions.checkerFramework}"
 }
 
 task copySources(type: Copy) {

--- a/templatefora-checker-qual/build.gradle
+++ b/templatefora-checker-qual/build.gradle
@@ -7,7 +7,8 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.checkerframework:checker:3.9.1'
+    implementation 'org.checkerframework:checker:3.10.0'
+    implementation 'org.checkerframework:checker-qual:3.10.0'
 }
 
 task copySources(type: Copy) {


### PR DESCRIPTION
It bothers me that the version number "3.10.0" appears both in `build.gradle` and `templatefora-checker-qual/build.gradle`.  Can the latter use the version defined in the former?