### PR TITLE
add jdk 17 support in the tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ install: true
 jdk:
   - openjdk8
   - openjdk11
+  - openjdk17
 
 script:
   - ./gradlew build --stacktrace

--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,25 @@ test {
     inputs.files("tests/templatefora")
     if (!JavaVersion.current().java9Compatible) {
         jvmArgs "-Xbootclasspath/p:${configurations.errorproneJavac.asPath}"
+    } else {
+        // A list of add-export and add-open arguments to be used when running the Checker Framework.
+        // Keep this list in sync with the list in the Checker Framework manual.
+        var compilerArgsForRunningCF = [
+                // These are required in Java 16+ because the --illegal-access option is set to deny
+                // by default.  None of these packages are accessed via reflection, so the module
+                // only needs to be exported, but not opened.
+                "--add-exports", "jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
+                "--add-exports", "jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
+                "--add-exports", "jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
+                "--add-exports", "jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
+                "--add-exports", "jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED",
+                "--add-exports", "jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED",
+                "--add-exports", "jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+                "--add-exports", "jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
+                // Required because the Checker Framework reflectively accesses private members in com.sun.tools.javac.comp.
+                "--add-opens", "jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED",
+        ]
+        jvmArgs += compilerArgsForRunningCF
     }
     testLogging {
         showStandardStreams = true


### PR DESCRIPTION
Previously, running on a Java 17 JDK caused the tests to crash because of a denied export.